### PR TITLE
해시태그 검색 페이지와 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package com.fastcampus.projectboard.controller;
 
 import com.fastcampus.projectboard.domain.type.SearchType;
+import com.fastcampus.projectboard.dto.ArticleDto;
 import com.fastcampus.projectboard.dto.response.ArticleResponse;
 import com.fastcampus.projectboard.dto.response.ArticleWithCommentsResponse;
 import com.fastcampus.projectboard.service.ArticleService;
@@ -49,6 +50,25 @@ public class ArticleController {
         model.addAttribute("article", article);
         model.addAttribute("articleComments", article.articleCommentsResponse());
         return "articles/detail";
+    }
+
+    @GetMapping("/search-hashtag")
+    public String searchHashtag(
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(size = 10, page = 0, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model
+    ) {
+
+        Page<ArticleResponse> articles = articleService.searchArticlesByHashtag(searchValue, pageable).map(ArticleResponse::from);
+        List<String> hashtags = articleService.getHashtags();
+        List<Integer> paginationBarNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+
+        model.addAttribute("articles", articles);
+        model.addAttribute("hashtags", hashtags);
+        model.addAttribute("paginationBarNumbers", paginationBarNumbers);
+        model.addAttribute("searchType", SearchType.HASHTAG);
+
+        return "articles/search-hashtag";
     }
 
 }

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Article;
 import com.fastcampus.projectboard.domain.QArticle;
+import com.fastcampus.projectboard.repository.querydsl.ArticleRepositoryCustom;
+import com.fastcampus.projectboard.repository.querydsl.ArticleRepositoryCustomImpl;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.domain.Page;
@@ -15,6 +17,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>,// 엔티티의 필드에 대한 모든 검색 기능 구현해줌
         QuerydslBinderCustomizer<QArticle> { // 추가적인 검색 기능을 위한 인터페이스
 
@@ -37,5 +40,4 @@ public interface ArticleRepository extends
         bindings.bind(article.createdAt).first(DateTimeExpression::eq);
         bindings.bind(article.createdBy).first(StringExpression::containsIgnoreCase);
     }
-
 }

--- a/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustom.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.fastcampus.projectboard.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<String> findAllDistinctHashtags();
+}

--- a/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,27 @@
+package com.fastcampus.projectboard.repository.querydsl;
+
+import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.domain.QArticle;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+import static com.fastcampus.projectboard.domain.QArticle.article;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom{
+
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtags() {
+        QArticle article = QArticle.article;
+        return from(article)
+                .distinct()
+                .select(article.hashtag)
+                .where(article.hashtag.isNotNull())
+                .fetch();
+    }
+}

--- a/src/main/java/com/fastcampus/projectboard/service/ArticleCommentService.java
+++ b/src/main/java/com/fastcampus/projectboard/service/ArticleCommentService.java
@@ -1,15 +1,19 @@
 package com.fastcampus.projectboard.service;
 
 import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.domain.ArticleComment;
 import com.fastcampus.projectboard.dto.ArticleCommentDto;
 import com.fastcampus.projectboard.repository.ArticleCommentRepository;
 import com.fastcampus.projectboard.repository.ArticleRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -21,25 +25,30 @@ public class ArticleCommentService {
 
     @Transactional(readOnly = true)
     public List<ArticleCommentDto> searchArticleComments(Long articleId) {
-        return List.of();
-//        Article article = articleRepository.findById(articleId).orElseThrow();
-//        return article.getArticleComments()
-//                .stream()
-//                .map(articleComment -> ArticleCommentDto.of(
-//                        article.getCreatedAt(),
-//                        article.getCreatedBy(),
-//                        article.getModifiedAt(),
-//                        article.getModifiedBy(),
-//                        article.getContent())
-//                ).toList();
+        return articleCommentRepository.findByArticle_Id(articleId)
+                .stream()
+                .map(ArticleCommentDto::from)
+                .toList();
     }
 
     public void saveArticleComment(ArticleCommentDto dto) {
+        try {
+            articleCommentRepository.save(dto.toEntity(articleRepository.getReferenceById(dto.articleId())));
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 저장 실패. 댓글의 게시글을 찾을 수 없습니다 - dto: {}", dto);
+        }
     }
 
     public void updateArticleComment(ArticleCommentDto dto) {
+        try {
+            ArticleComment articleComment = articleCommentRepository.getReferenceById(dto.id());
+            if (dto.content() != null) { articleComment.setContent(dto.content()); }
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 업데이트 실패. 댓글을 찾을 수 없습니다 - dto: {}", dto);
+        }
     }
 
     public void deleteArticleComment(Long articleCommentId) {
+        articleCommentRepository.deleteById(articleCommentId);
     }
 }

--- a/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @Transactional
@@ -65,5 +67,19 @@ public class ArticleService {
 
     public void deleteArticle(long articleId) {
         articleRepository.deleteById(articleId);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesByHashtag(String hashtag, Pageable pageable) {
+        if (hashtag == null || hashtag.isBlank()) {
+            return Page.empty(pageable);
+        }
+
+        return articleRepository.findByHashtag(hashtag, pageable).map(ArticleDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getHashtags() {
+        return articleRepository.findAllDistinctHashtags();
     }
 }

--- a/src/main/resources/static/css/article-content.css
+++ b/src/main/resources/static/css/article-content.css
@@ -1,0 +1,7 @@
+#article-content > pre {
+    white-space: pre-wrap; /* Since CSS 2.1 */
+    white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+    white-space: -pre-wrap; /* Opera 4-6 */
+    white-space: -o-pre-wrap; /* Opera 7 */
+    word-wrap: break-word; /* Internet Explorer 5.5+ */
+}

--- a/src/main/resources/templates/articles/search-hashtag.html
+++ b/src/main/resources/templates/articles/search-hashtag.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}">
+    <link rel="stylesheet" th:href="@{/css/table-header.css}">
+    <script defer th:src="@{js/bootstrap.min.js}"></script>
+</head>
+<body class="d-flex flex-column min-vh-100">
+  <header th:replace="layout/header::header"></header>
+
+  <main class="container flex-grow-1">
+      <header class="py-5 text-center">
+          <h1>Hashtags</h1>
+      </header>
+
+      <section class="row">
+          <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+              <div class="p-2" th:each="hashtag : ${hashtags}">
+                  <h2 class="text-center lh-lg font-monospace">
+                      <a class="text-reset" th:text="${hashtag}"
+                         th:href="@{/articles/search-hashtag(
+                         page=${param.page},
+                         sort=${param.sort},
+                         searchType=${searchType.name},
+                         searchValue=${hashtag}
+                         )}"
+                      ></a>
+                  </h2>
+              </div>
+          </div>
+      </section>
+
+      <table class="table" id="article-table">
+          <thead>
+          <tr>
+              <th class="col-5">
+                  <a th:href="@{/articles/search-hashtag(searchType=${searchType.name},
+                                                searchValue=${param.searchValue},
+                                                page=${articles.number},
+                                                sort='title' + (*{articles.sort.getOrderFor('title')} != null ? (*{articles.sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''))}" th:text="제목">
+                  </a>
+              </th>
+              <th class="col-2">
+                  <a th:href="@{/articles/search-hashtag(searchType=${searchType.name},
+                                                searchValue=${param.searchValue},
+                                                page=${articles.number},
+                                                sort='hashtag' + (*{articles.sort.getOrderFor('hashtag')} != null ? (*{articles.sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''))}" th:text="본문">
+                  </a>
+              </th>
+              <th class="col">
+                  <a th:href="@{/articles/search-hashtag(searchType=${searchType.name},
+                                                searchValue=${param.searchValue},
+                                                page=${articles.number},
+                                                sort='userAccount.userId' + (*{articles.sort.getOrderFor('userAccount.userId')} != null ? (*{articles.sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''))}" th:text="작성자">
+                  </a>
+              </th>
+              <th class="col">
+                  <a th:href="@{/articles/search-hashtag(searchType=${searchType.name},
+                                                searchValue=${param.searchValue},
+                                                page=${articles.number},
+                                                sort='createdAt' + (*{articles.sort.getOrderFor('createdAt')} != null ? (*{articles.sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''))}" th:text="작성일">
+                  </a>
+              </th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr th:each="article : ${articles}">
+              <td>
+                  <a th:href="@{|/articles/${article.id}|}" th:text="${article.title}"></a>
+              </td>
+              <td>
+                  <span class="d-inline-block text-truncate" style="max-width: 300px;" th:text="${article.content}"></span>
+              </td>
+              <td th:text="${article.nickname}"></td>
+              <td th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}"></td>
+          </tr>
+          </tbody>
+      </table>
+
+      <nav id="pagination" aria-label="Page navigation">
+          <ul class="pagination justify-content-center">
+              <li class="page-item">
+                  <a class="page-link" th:classappend="${articles.number <= 0} ? 'disabled' : ''"  th:href="@{/articles(page=${articles.number - 1},searchType=${searchType.name},searchValue=${param.searchValue})}" th:text="Previous"></a>
+              </li>
+              <li th:each="page : ${paginationBarNumbers}">
+                  <a class="page-link" th:classappend="${articles.number == page} ? 'active' : ''" th:href="@{/articles(page=${page},searchType=${searchType.name},searchValue=${param.searchValue})}" th:text="${page + 1}"></a>
+              </li>
+              <li class="page-item">
+                  <a class="page-link" th:classappend="${articles.number >= articles.totalPages - 1} ? 'disabled' : ''" th:href="@{/articles(page=${articles.number + 1},searchType=${searchType.name},searchValue=${param.searchValue})}" th:text="Next"></a>
+              </li>
+          </ul>
+      </nav>
+
+
+  </main>
+
+  <footer th:replace="layout/footer::footer"></footer>
+</body>
+</html>

--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -141,7 +141,7 @@ class ArticleControllerTest {
         then(articleService).should().getArticle(articleId);
     }
 
-    @Disabled("구현중..")
+    @Disabled
     @DisplayName("[view][GET] - 게시글 검색 전용 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingArticleSearchView_thenReturnsArticleSearchView() throws Exception {
@@ -150,21 +150,58 @@ class ArticleControllerTest {
         // When & Then
         mvc.perform(get("/articles/search"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.TEXT_HTML))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/search"));
     }
 
-    @Disabled("구현중..")
     @DisplayName("[view][GET] - 게시글 해시태그 검색 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingArticleHashtagSearchView_thenReturnsArticleHashtagSearchView() throws Exception {
         // Given
+        given(articleService.searchArticlesByHashtag(eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of());
+        given(articleService.getHashtags()).willReturn(List.of("#java", "#spring", "jpa"));
 
         // When & Then
-        mvc.perform(get("/articles/hashtag"))
+        mvc.perform(get("/articles/search-hashtag"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.TEXT_HTML))
-                .andExpect(view().name("articles/search-hashtag"));
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/search-hashtag"))
+                .andExpect(model().attribute("articles", Page.empty()))
+                .andExpect(model().attributeExists("hashtags"))
+                .andExpect(model().attributeExists("paginationBarNumbers"))
+                .andExpect(model().attributeExists("searchType"));
+
+        then(articleService).should().searchArticlesByHashtag(eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+        then(articleService).should().getHashtags();
+    }
+
+    @DisplayName("[view][GET] - 게시글 해시태그 검색 페이지 - 정상 호출, 해시태그 입력")
+    @Test
+    void givenHashtag_whenRequestingArticleHashtagSearchView_thenReturnsArticleHashtagSearchView() throws Exception {
+        // Given
+        String hashtag = "#java";
+        given(articleService.searchArticlesByHashtag(eq(hashtag), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of());
+        given(articleService.getHashtags()).willReturn(List.of("#java", "#spring", "jpa"));
+
+
+        // When & Then
+        mvc.perform(get("/articles/search-hashtag")
+                        .queryParam("searchValue", hashtag)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/search-hashtag"))
+                .andExpect(model().attribute("articles", Page.empty()))
+                .andExpect(model().attributeExists("hashtags"))
+                .andExpect(model().attributeExists("paginationBarNumbers"))
+                .andExpect(model().attributeExists("searchType"));
+
+        then(articleService).should().searchArticlesByHashtag(eq(hashtag), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+        then(articleService).should().getHashtags();
     }
 
     private ArticleWithCommentsDto createArticleWithCommentsDto() {

--- a/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("View 컨트롤러 - 인증 ")
 @Import(SecurityConfig.class)
-@WebMvcTest
+@WebMvcTest(Void.class)
 public class AuthControllerTest {
 
     private final MockMvc mvc;

--- a/src/test/java/com/fastcampus/projectboard/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/ArticleCommentServiceTest.java
@@ -38,7 +38,6 @@ class ArticleCommentServiceTest {
     @Mock
     private ArticleRepository articleRepository;
 
-    // todo: CRUD Test!
     @DisplayName("게시글 아이디로 조회하면, 해당 게시글 댓글 리스트를 반환한다.")
     @Test
     void givenArticleId_whenSearchingComments_thenReturnsComments() {
@@ -51,8 +50,10 @@ class ArticleCommentServiceTest {
         List<ArticleCommentDto> articleComments = sut.searchArticleComments(articleId);
 
         // Then
-        assertThat(articleComments).isNotNull();
-        then(articleRepository).should().findById(articleId);
+        assertThat(articleComments)
+                .hasSize(1)
+                .first().hasFieldOrPropertyWithValue("content", expected.getContent());
+        then(articleCommentRepository).should().findByArticle_Id(articleId);
     }
 
     @DisplayName("댓글 정보를 입력하면, 댓글을 저장한다.")

--- a/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,6 +67,53 @@ class ArticleServiceTest {
         assertThat(articles).isEmpty();
         then(articleRepository).should().findByTitleContaining(searchKeyword, pageable);
     }
+
+    @DisplayName("검색어 없이 게시글을 해시태그 검색하면, 빈 페이지를 반환한다.")
+    @Test
+    void givenNoSearchParameters_whenSearchingArticlesByHashtag_thenReturnsEmptyPage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesByHashtag(null, pageable);
+
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("게시글을 해시태그 검색하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenHashtag_whenSearchingArticlesByHashtag_thenReturnsArticlesPage() {
+        // Given
+        String hashtag = "#java";
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findByHashtag(hashtag, pageable)).willReturn(Page.empty(pageable));
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesByHashtag(hashtag, pageable);
+
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).should().findByHashtag(hashtag, pageable);
+    }
+
+    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다.")
+    @Test
+    void given_when_then() {
+        // Given
+        List<String> expectedHashtag = List.of("#java", "#spring", "jpa");
+        given(articleRepository.findAllDistinctHashtags()).willReturn(expectedHashtag);
+
+        // When
+        List<String> actualHashtags = sut.getHashtags();
+
+        // Then
+        assertThat(actualHashtags).isEqualTo(expectedHashtag);
+        then(articleRepository).should().findAllDistinctHashtags();
+    }
+
+
 
     @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
     @Test

--- a/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
@@ -36,6 +36,7 @@ class ArticleServiceTest {
     @Mock // 가짜 객체를 만듦 -> 스프링 빈에 등록되지 않음 -> @MockBean 보다 빠름
     private ArticleRepository articleRepository;
 
+
     @DisplayName("검색어 없이 게시글을 검색하면, 게시글 페이지를 반환한다.")
     @Test
     void givenNoSearchParameters_whenSearchingArticles_thenReturnsArticlePage() {


### PR DESCRIPTION
해시태그 페이지와 관련 기능 구현
Querydsl 사용해서 해시태그 기능 구현함.
실패하는 테스트 코드가 있어 수정함.

This closes #22 